### PR TITLE
Specify files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "glob-stream": "^6.1.0",
     "through2": "^2.0.1",
     "xtend": "^4.0.0"
-  }
+  },
+	"files": [
+		"help-me.js"
+	]
 }


### PR DESCRIPTION
Currently the `doc` and `fixture` folders and various dotfiles such as `.travis.yml` are being published to npm. 
This PR excludes them using the using the [`files`](https://docs.npmjs.com/files/package.json#files) whitelist in the `package.json`.