### PR TITLE
fix: print help when no args pass on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:

--- a/help-me.js
+++ b/help-me.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fs = require('fs')
-const path = require('path').posix
 const { PassThrough, pipeline } = require('readable-stream')
 const glob = require('glob')
 
@@ -57,12 +56,7 @@ function helpMe (opts) {
       files = files
         .map(function (file) {
           if (process.platform === 'win32') {
-            const dirPaths = opts.dir.split('\\')
-            let tempDir = ''
-            dirPaths.forEach((dirPath) => {
-              tempDir = path.join(tempDir, dirPath)
-            })
-            opts.dir = tempDir
+            opts.dir = opts.dir.split('\\').join('/')
           }
 
           const relative = file.replace(opts.dir, '').replace(/^\//, '')


### PR DESCRIPTION
This PR should fix https://github.com/fastify/fastify-cli/issues/388 

The reason `fastify-cli` doesn't print help on a windows machine is because of the path. Windows use `\\` and Linux use `/`

When using `help-me`, we use node.js native module `path`, which depending on the OS you're using, use `\\` or `/`.
![image](https://user-images.githubusercontent.com/37709578/122637494-63d85e80-d108-11eb-8c59-91c8a879aeed.png)

There are multiple ways to fix the issue, but the most simple one is to just convert the user-provided path to the POSIX path.
(e.g. `work/help-me/doc` )