### PR TITLE
fix: absolute dir paths on Windows

### DIFF
--- a/help-me.js
+++ b/help-me.js
@@ -50,15 +50,15 @@ function helpMe (opts) {
         .join('[ /]+')
     )
 
+    if (process.platform === 'win32') {
+      opts.dir = opts.dir.split('\\').join('/')
+    }
+
     glob(opts.dir + '/**/*' + opts.ext, function (err, files) {
       if (err) return out.emit('error', err)
 
       files = files
         .map(function (file) {
-          if (process.platform === 'win32') {
-            opts.dir = opts.dir.split('\\').join('/')
-          }
-
           const relative = file.replace(opts.dir, '').replace(/^\//, '')
           return { file, relative }
         })

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 const test = require('tape')
 const concat = require('concat-stream')
 const fs = require('fs')
+const path = require('path')
 const helpMe = require('./')
 
 test('throws if no directory is passed', function (t) {
@@ -39,11 +40,25 @@ test('throws if the directory cannot be accessed', function (t) {
   t.end()
 })
 
-test('show a generic help.txt from a folder to a stream', function (t) {
+test('show a generic help.txt from a folder to a stream with relative path in dir', function (t) {
   t.plan(2)
 
   helpMe({
     dir: 'fixture/basic'
+  }).createStream()
+    .pipe(concat(function (data) {
+      fs.readFile('fixture/basic/help.txt', function (err, expected) {
+        t.error(err)
+        t.equal(data.toString(), expected.toString())
+      })
+    }))
+})
+
+test('show a generic help.txt from a folder to a stream with absolute path in dir', function (t) {
+  t.plan(2)
+
+  helpMe({
+    dir: path.join(__dirname, 'fixture/basic')
   }).createStream()
     .pipe(concat(function (data) {
       fs.readFile('fixture/basic/help.txt', function (err, expected) {


### PR DESCRIPTION
Fixes the issue that prevented this from working on Windows because of the way this package is used in fastify-cli, which provides a dir option which is an absolute path.

See https://github.com/fastify/fastify-cli/issues/492