### PR TITLE
fix: Make default stream correctly emit streaming events

### DIFF
--- a/help-me.js
+++ b/help-me.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const { PassThrough, Writable, pipeline } = require('stream')
 const glob = require('glob')
+const process = require('process')
 
 const defaults = {
   ext: '.txt',

--- a/help-me.js
+++ b/help-me.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fs = require('fs')
-const { PassThrough, pipeline } = require('readable-stream')
+const { PassThrough, Writable, pipeline } = require('stream')
 const glob = require('glob')
 
 const defaults = {
@@ -16,6 +16,14 @@ function isDirectory (path) {
   } catch (err) {
     return false
   }
+}
+
+function createDefaultStream () {
+  return new Writable({
+    write (chunk, encoding, callback) {
+      process.stdout.write(chunk, callback)
+    }
+  })
 }
 
 function helpMe (opts) {
@@ -94,7 +102,7 @@ function helpMe (opts) {
 
   function toStdout (args = [], opts) {
     opts = opts || {}
-    const stream = opts.stream || process.stdout
+    const stream = opts.stream || createDefaultStream()
     const _onMissingHelp = opts.onMissingHelp || onMissingHelp
     return new Promise((resolve, reject) => {
       createStream(args)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "commist": "^2.0.0",
     "concat-stream": "^2.0.0",
     "pre-commit": "^1.1.3",
+    "proxyquire": "^2.1.3",
     "standard": "^16.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.0.0"

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 const test = require('tape')
 const concat = require('concat-stream')
 const fs = require('fs')
+const os = require('os')
 const path = require('path')
 const helpMe = require('./')
 const proxyquire = require('proxyquire')
@@ -330,7 +331,7 @@ test('should allow for awaiting the response with default stdout stream', async 
 
   let completed = false
   stdout.write = (data, cb) => {
-    t.equal(data.toString(), 'hello world\n')
+    t.equal(data.toString(), 'hello world' + os.EOL)
     completed = true
     cb()
   }

--- a/test.js
+++ b/test.js
@@ -317,3 +317,16 @@ test('toStdout without factory', async function (t) {
 
   t.ok(completed)
 })
+
+test('should allow for awaiting the response with default stdout stream', async function (t) {
+  t.plan(1)
+
+  try {
+    await helpMe({
+      dir: 'fixture/basic'
+    }).toStdout([])
+    t.ok('awaited correctly')
+  } catch {
+    t.fail('should not reject')
+  }
+})


### PR DESCRIPTION
It's currently impossible to correctly await on `help.toStdout` when using default `process.stdout`, as the `pipe` method returns the destination stream (`stdout` in this case), and attached `end` and `finish` events will be never emitted, effecting in `Promise` never being resolved.

As per https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback and https://nodejs.org/api/process.html#a-note-on-process-io

> The [process.stderr](https://nodejs.org/api/process.html#processstderr) and [process.stdout](https://nodejs.org/api/process.html#processstdout) Writable streams are never closed until the Node.js process exits, regardless of the specified options.

Using a custom `Writable` here will print to the `stdout` as a side-effect, but will still pass through all necessary events.